### PR TITLE
Added more exception handling to throw when count of I/O in Tx is les…

### DIFF
--- a/src/main.c
+++ b/src/main.c
@@ -785,6 +785,9 @@ void parse_cbor_transaction() {
           itx_count++;
       }
       offset++;
+      if(itx_count < 1) {
+          THROW(0x5902);
+      }
   } else {
       // Invalid TX, must have at least one input
       error = true;
@@ -871,8 +874,11 @@ void parse_cbor_transaction() {
               THROW(0x5903);
           }
       }
+      if(otx_index < 1) {
+          THROW(0x5904);
+      }
   } else {
-      // Invalid TX, must have at least one output
+      // Invalid TX, missing Outputs array
       error = true;
       THROW(0x5904);
   }


### PR DESCRIPTION
Looks like both the checks for 5902 and 5904 were not broad enough. Was checking for the indefinite array. Now also checking that there was something inside the array. Test data for 1x0 and 0x1 transactions available in the example.